### PR TITLE
Feat/use only `edityourfilm` bucket for strapi assets storage

### DIFF
--- a/config/middlewares.js
+++ b/config/middlewares.js
@@ -13,18 +13,14 @@ module.exports = [
             "data:",
             "blob:",
             "market-assets.strapi.io",
-            process.env.ENV === "prod"
-              ? "edityourfilm-prod.s3.fr-par.scw.cloud"
-              : "edityourfilm.s3.fr-par.scw.cloud", // should be changed to "edityourfilm-dev.s3.fr-par.scw.cloud",
+            "edityourfilm.s3.fr-par.scw.cloud",
           ],
           "media-src": [
             "'self'",
             "data:",
             "blob:",
             "market-assets.strapi.io",
-            process.env.ENV === "prod"
-              ? "edityourfilm-prod.s3.fr-par.scw.cloud"
-              : "edityourfilm.s3.fr-par.scw.cloud", // should be changed to "edityourfilm-dev.s3.fr-par.scw.cloud",
+            "edityourfilm.s3.fr-par.scw.cloud",
           ],
           upgradeInsecureRequests: null,
         },


### PR DESCRIPTION
This PR goal is to simplify strapi assets storage, by only using one bucket: `edityourfilm`.